### PR TITLE
Improve SV06 Plus LCD functionality when printing via USB

### DIFF
--- a/MarlinSV06Plus/Marlin/Configuration.h
+++ b/MarlinSV06Plus/Marlin/Configuration.h
@@ -1437,7 +1437,7 @@
  * RAMPS-based boards use SERVO3_PIN for the first runout sensor.
  * For other boards you may need to define FIL_RUNOUT_PIN, FIL_RUNOUT2_PIN, etc.
  */
-#define FILAMENT_RUNOUT_SENSOR 
+#define FILAMENT_RUNOUT_SENSOR
 #if ENABLED(FILAMENT_RUNOUT_SENSOR)
   #define FIL_RUNOUT_ENABLED_DEFAULT true // Enable the sensor on startup. Override with M412 followed by M500.
   #define NUM_RUNOUT_SENSORS   1          // Number of sensors, up to one per extruder. Define a FIL_RUNOUT#_PIN for each.
@@ -2783,6 +2783,7 @@
 //#define DWIN_MARLINUI_PORTRAIT
 //#define DWIN_MARLINUI_LANDSCAPE
 #define RTS_AVAILABLE
+#define HAS_DISPLAY 1
 
 //
 // Touch Screen Settings

--- a/MarlinSV06Plus/Marlin/Configuration_adv.h
+++ b/MarlinSV06Plus/Marlin/Configuration_adv.h
@@ -1298,7 +1298,7 @@
   //#define LCD_DECIMAL_SMALL_XY
 
   // Add an 'M73' G-code to set the current percentage
-  //#define LCD_SET_PROGRESS_MANUALLY
+  #define LCD_SET_PROGRESS_MANUALLY
 
   // Show the E position (filament used) during printing
   //#define LCD_SHOW_E_TOTAL
@@ -1306,10 +1306,10 @@
 
 // LCD Print Progress options
 #if EITHER(SDSUPPORT, LCD_SET_PROGRESS_MANUALLY)
-  #if ANY(HAS_MARLINUI_U8GLIB, EXTENSIBLE_UI, HAS_MARLINUI_HD44780, IS_TFTGLCD_PANEL, IS_DWIN_MARLINUI)
-    //#define SHOW_REMAINING_TIME         // Display estimated time to completion
+  #if ANY(HAS_MARLINUI_U8GLIB, EXTENSIBLE_UI, HAS_MARLINUI_HD44780, IS_TFTGLCD_PANEL, IS_DWIN_MARLINUI,RTS_AVAILABLE)
+    #define SHOW_REMAINING_TIME         // Display estimated time to completion
     #if ENABLED(SHOW_REMAINING_TIME)
-      //#define USE_M73_REMAINING_TIME    // Use remaining time from M73 command instead of estimation
+      #define USE_M73_REMAINING_TIME    // Use remaining time from M73 command instead of estimation
       //#define ROTATE_PROGRESS_DISPLAY   // Display (P)rogress, (E)lapsed, and (R)emaining time
     #endif
   #endif
@@ -3836,7 +3836,7 @@
 #define HOST_ACTION_COMMANDS
 #if ENABLED(HOST_ACTION_COMMANDS)
   //#define HOST_PAUSE_M76
-  //#define HOST_PROMPT_SUPPORT
+  #define HOST_PROMPT_SUPPORT
   //#define HOST_START_MENU_ITEM  // Add a menu item that tells the host to start
 #endif
 

--- a/MarlinSV06Plus/Marlin/src/gcode/bedlevel/abl/G29.cpp
+++ b/MarlinSV06Plus/Marlin/src/gcode/bedlevel/abl/G29.cpp
@@ -224,6 +224,10 @@ public:
 G29_TYPE GcodeSuite::G29() {
   DEBUG_SECTION(log_G29, "G29", DEBUGGING(LEVELING));
 
+  #if ENABLED(RTS_AVAILABLE)
+    RTS_Set_Waitway(3);
+  #endif
+
   TERN_(PROBE_MANUALLY, static) G29_State abl;
 
   TERN_(FULL_REPORT_TO_HOST_FEATURE, set_and_report_grblstate(M_PROBE));

--- a/MarlinSV06Plus/Marlin/src/gcode/lcd/M73.cpp
+++ b/MarlinSV06Plus/Marlin/src/gcode/lcd/M73.cpp
@@ -45,6 +45,13 @@
  */
 void GcodeSuite::M73() {
 
+  // Don't set the LCD progress if homing is needed.
+  // The SV06 Plus LCD progress screens provide pause and cancel options which
+  // malfunction if the printer has not been homed.
+  if (homing_needed_error()) {
+    return;
+  }
+
   #if ENABLED(DWIN_CREALITY_LCD_ENHANCED)
 
     DWIN_Progress_Update();

--- a/MarlinSV06Plus/Marlin/src/gcode/lcd/M73.cpp
+++ b/MarlinSV06Plus/Marlin/src/gcode/lcd/M73.cpp
@@ -68,13 +68,11 @@ void GcodeSuite::M73() {
         rtscheck.RTS_SndData((unsigned char)percentComplete, PRINT_PROCESS_VP);
         if (percentComplete == 100)
         {
-          rtscheck.RTS_SndData(0, PRINT_TIME_HOUR_VP);
-          rtscheck.RTS_SndData(0, PRINT_TIME_MIN_VP);
-          rtscheck.RTS_SndData(0, PRINT_SURPLUS_TIME_HOUR_VP);
-          rtscheck.RTS_SndData(0, PRINT_SURPLUS_TIME_MIN_VP);
-          rtscheck.RTS_SDcard_Stop();
-          PrintFlag = 0;
-          Update_Time_Value = 0;
+            RTS_USBPrint_Finish();
+        }
+        else
+        {
+            RTS_USBPrint_Set();
         }
       #endif
 

--- a/MarlinSV06Plus/Marlin/src/gcode/lcd/M73.cpp
+++ b/MarlinSV06Plus/Marlin/src/gcode/lcd/M73.cpp
@@ -30,6 +30,10 @@
 
 #if ENABLED(DWIN_CREALITY_LCD_ENHANCED)
   #include "../../lcd/e3v2/enhanced/dwin.h"
+#elif ENABLED(RTS_AVAILABLE)
+  unsigned char percentComplete = 0;
+  uint16_t timeRemaining = 0;
+  #include "../../lcd/sv06p/LCD_RTS.h"
 #endif
 
 
@@ -50,11 +54,30 @@ void GcodeSuite::M73() {
     if (parser.seenval('P'))
       ui.set_progress((PROGRESS_SCALE) > 1
         ? parser.value_float() * (PROGRESS_SCALE)
-        : parser.value_byte()
-      );
+        : parser.value_byte());
+      #if ENABLED(RTS_AVAILABLE)
+        percentComplete = parser.value_byte();
+        rtscheck.RTS_SndData((unsigned char)percentComplete, PRINT_PROCESS_ICON_VP);
+        rtscheck.RTS_SndData((unsigned char)percentComplete, PRINT_PROCESS_VP);
+        if (percentComplete == 100)
+        {
+          rtscheck.RTS_SndData(0, PRINT_TIME_HOUR_VP);
+          rtscheck.RTS_SndData(0, PRINT_TIME_MIN_VP);
+          rtscheck.RTS_SndData(0, PRINT_SURPLUS_TIME_HOUR_VP);
+          rtscheck.RTS_SndData(0, PRINT_SURPLUS_TIME_MIN_VP);
+          rtscheck.RTS_SDcard_Stop();
+          PrintFlag = 0;
+          Update_Time_Value = 0;
+        }
+      #endif
 
     #if ENABLED(USE_M73_REMAINING_TIME)
-      if (parser.seenval('R')) ui.set_remaining_time(60 * parser.value_ulong());
+      if (parser.seenval('R')) ui.set_remaining_time(parser.value_ulong());
+      #if ENABLED(RTS_AVAILABLE)
+        timeRemaining = parser.value_ulong();
+        rtscheck.RTS_SndData((timeRemaining / 60), PRINT_SURPLUS_TIME_HOUR_VP);
+        rtscheck.RTS_SndData((timeRemaining % 60), PRINT_SURPLUS_TIME_MIN_VP);
+      #endif
     #endif
 
   #endif

--- a/MarlinSV06Plus/Marlin/src/gcode/lcd/M73.cpp
+++ b/MarlinSV06Plus/Marlin/src/gcode/lcd/M73.cpp
@@ -32,6 +32,7 @@
   #include "../../lcd/e3v2/enhanced/dwin.h"
 #endif
 
+
 /**
  * M73: Set percentage complete (for display on LCD)
  *

--- a/MarlinSV06Plus/Marlin/src/lcd/sv06p/LCD_RTS.cpp
+++ b/MarlinSV06Plus/Marlin/src/lcd/sv06p/LCD_RTS.cpp
@@ -2946,4 +2946,9 @@ void RTS_MoveAxisHoming()
   rtscheck.RTS_SndData(10*current_position[Y_AXIS], AXIS_Y_COORD_VP);
   rtscheck.RTS_SndData(10*current_position[Z_AXIS], AXIS_Z_COORD_VP);
 }
+
+void RTS_Set_Waitway(const char new_waitway) {
+    waitway = new_waitway;
+}
+
 #endif //RTS_AVAILABLE

--- a/MarlinSV06Plus/Marlin/src/lcd/sv06p/LCD_RTS.cpp
+++ b/MarlinSV06Plus/Marlin/src/lcd/sv06p/LCD_RTS.cpp
@@ -34,6 +34,9 @@
 #endif
 #if ENABLED(RTS_AVAILABLE)
 #define CHECKFILEMENT false
+#if ENABLED(HOST_ACTION_COMMANDS)
+  #include "../../feature/host_actions.h"
+#endif
 
 float zprobe_zoffset;
 float last_zoffset = 0.0;
@@ -876,6 +879,9 @@ void RTSSHOW::RTS_HandleData()
         RTS_SndData(0, PRINT_SURPLUS_TIME_HOUR_VP);
         RTS_SndData(0, PRINT_SURPLUS_TIME_MIN_VP);
         RTS_SDcard_Stop();
+        #ifdef ACTION_ON_CANCEL
+          host_action_cancel();
+        #endif
         PrintFlag = 0;
         Update_Time_Value = 0;
       }

--- a/MarlinSV06Plus/Marlin/src/lcd/sv06p/LCD_RTS.cpp
+++ b/MarlinSV06Plus/Marlin/src/lcd/sv06p/LCD_RTS.cpp
@@ -878,10 +878,13 @@ void RTSSHOW::RTS_HandleData()
         RTS_SndData(0, PRINT_TIME_MIN_VP);
         RTS_SndData(0, PRINT_SURPLUS_TIME_HOUR_VP);
         RTS_SndData(0, PRINT_SURPLUS_TIME_MIN_VP);
-        RTS_SDcard_Stop();
         #ifdef ACTION_ON_CANCEL
           host_action_cancel();
+          if (card.isPrinting()) {
+            planner.synchronize();
+          }
         #endif
+        RTS_SDcard_Stop();
         PrintFlag = 0;
         Update_Time_Value = 0;
       }

--- a/MarlinSV06Plus/Marlin/src/lcd/sv06p/LCD_RTS.cpp
+++ b/MarlinSV06Plus/Marlin/src/lcd/sv06p/LCD_RTS.cpp
@@ -2956,6 +2956,54 @@ void RTS_MoveAxisHoming()
   rtscheck.RTS_SndData(10*current_position[Z_AXIS], AXIS_Z_COORD_VP);
 }
 
+void RTS_USBPrint_Set() {
+    if (PrintFlag > 0) {
+        return;
+    }
+    rtscheck.RTS_SndData(0, PRINT_TIME_HOUR_VP);
+    rtscheck.RTS_SndData(0, PRINT_TIME_MIN_VP);
+    rtscheck.RTS_SndData(0, PRINT_SURPLUS_TIME_HOUR_VP);
+    rtscheck.RTS_SndData(0, PRINT_SURPLUS_TIME_MIN_VP);
+    PrintFlag = 1;
+    print_job_timer.reset();
+    print_job_timer.start();
+    // Show print progress LCD screen
+    rtscheck.RTS_SndData("USB Print", PRINT_FILE_TEXT_VP);
+    if(Mode_flag)
+    {
+        rtscheck.RTS_SndData(1, Time_VP);
+        rtscheck.RTS_SndData(ExchangePageBase + 11, ExchangepageAddr);
+    }
+    else
+    {
+        rtscheck.RTS_SndData(1, Time1_VP);
+        rtscheck.RTS_SndData(ExchangePageBase + 66, ExchangepageAddr);
+    }
+}
+
+void RTS_USBPrint_Finish() {
+    if (PrintFlag == 0) {
+        return;
+    }
+    rtscheck.RTS_SndData(0, PRINT_TIME_HOUR_VP);
+    rtscheck.RTS_SndData(0, PRINT_TIME_MIN_VP);
+    rtscheck.RTS_SndData(0, PRINT_SURPLUS_TIME_HOUR_VP);
+    rtscheck.RTS_SndData(0, PRINT_SURPLUS_TIME_MIN_VP);
+    PrintFlag = 0;
+    Update_Time_Value = 0;
+    print_job_timer.stop();
+    // Return LCD to home screen
+    rtscheck.RTS_SndData(0, PRINT_FILE_TEXT_VP);
+    if(Mode_flag)
+    {
+        rtscheck.RTS_SndData(ExchangePageBase + 1, ExchangepageAddr);
+    }
+    else
+    {
+        rtscheck.RTS_SndData(ExchangePageBase + 56, ExchangepageAddr);
+    }
+}
+
 void RTS_Set_Waitway(const char new_waitway) {
     waitway = new_waitway;
 }

--- a/MarlinSV06Plus/Marlin/src/lcd/sv06p/LCD_RTS.h
+++ b/MarlinSV06Plus/Marlin/src/lcd/sv06p/LCD_RTS.h
@@ -398,3 +398,4 @@ extern int PrintFlag;
 void RTS_AutoBedLevelPage();
 void RTS_MoveAxisHoming();
 void RTS_PauseMoveAxisPage();
+void RTS_Set_Waitway(const char new_waitway);

--- a/MarlinSV06Plus/Marlin/src/lcd/sv06p/LCD_RTS.h
+++ b/MarlinSV06Plus/Marlin/src/lcd/sv06p/LCD_RTS.h
@@ -398,4 +398,6 @@ extern int PrintFlag;
 void RTS_AutoBedLevelPage();
 void RTS_MoveAxisHoming();
 void RTS_PauseMoveAxisPage();
+void RTS_USBPrint_Set();
+void RTS_USBPrint_Finish();
 void RTS_Set_Waitway(const char new_waitway);

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ with customized firmware.
 * Using [`M73`][M73], display progress and remaining time on the LCD just like
   when printing from the SD card. The LCD's print cancel button now works to
   stop the print, so long as the client supports the cancel host action (which
-  Octoprint does). This is adapted from
+  [Octoprint][octoprint] does). This is adapted from
   [the LCD branch of daleye's fork][daleye-fork-lcd-branch].
 
 # Building the firmware
@@ -90,6 +90,7 @@ last resort,
 [daleye-fork-lcd-branch]: https://github.com/daleye/SV06-PLUS/compare/42f16c0fdb5e7de022d615e0a665aed042e0be49...b5ec92a7a4487f183714fc544ca0ef5fd8cb180a
 [local-firmware-copy]: /SV06%20Plus_V1.1.5_0324.bin
 [marlin]: https://marlinfw.org/
+[octoprint]: https://octoprint.org/
 [pipx]: https://github.com/pypa/pipx
 [platformio]: https://platformio.org/
 [sovol-download-page]: https://www.sovol3d.com/pages/download

--- a/README.md
+++ b/README.md
@@ -4,6 +4,18 @@ This is a fork of
 [Sovol's official repository for the SV06 Plus 3D printer][sovol-sv06-plus-repo]
 with customized firmware.
 
+# New features
+
+* On bed leveling ([`G29`][G29]) completion, return the LCD to the leveling
+  screen. Originally the LCD would get stuck displaying the final leveling grid
+  with no option to exit if `G29` were invoked via serial.
+
+* Using [`M73`][M73], display progress and remaining time on the LCD just like
+  when printing from the SD card. The LCD's print cancel button now works to
+  stop the print, so long as the client supports the cancel host action (which
+  Octoprint does). This is adapted from
+  [the LCD branch of daleye's fork][daleye-fork-lcd-branch].
+
 # Building the firmware
 
 The firmware ([Marlin][marlin]) is built with a tool called
@@ -73,6 +85,9 @@ last resort,
 [I am including a copy of Sovol's official SV06 Plus firmware (version 1.1.5) in this repository as `SV06 Plus_V1.1.5_0324.bin`][local-firmware-copy].
 
 
+[G29]: https://marlinfw.org/docs/gcode/G029-abl-bilinear.html
+[M73]: https://marlinfw.org/docs/gcode/M073.html
+[daleye-fork-lcd-branch]: https://github.com/daleye/SV06-PLUS/compare/42f16c0fdb5e7de022d615e0a665aed042e0be49...b5ec92a7a4487f183714fc544ca0ef5fd8cb180a
 [local-firmware-copy]: /SV06%20Plus_V1.1.5_0324.bin
 [marlin]: https://marlinfw.org/
 [pipx]: https://github.com/pypa/pipx


### PR DESCRIPTION
New features:

* On bed leveling (`G29`) completion, return the LCD to the leveling screen.
  Originally the LCD would get stuck displaying the final leveling grid with no
  option to exit if `G29` were invoked via serial.

* Using `M73`, display progress and remaining time on the LCD just like when
  printing from the SD card. The LCD's print cancel button now works to stop the
  print, so long as the client supports the cancel host action (which Octoprint
  does). This is adapted from the LCD branch of daleye's fork:
  https://github.com/daleye/SV06-PLUS/compare/42f16c0fdb5e7de022d615e0a665aed042e0be49...b5ec92a7a4487f183714fc544ca0ef5fd8cb180a
