### PR TITLE
Remove unused kill_screen call to solve null reference

### DIFF
--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -869,7 +869,7 @@ void kill(PGM_P const lcd_error/*=nullptr*/, PGM_P const lcd_component/*=nullptr
   if (lcd_error) { SERIAL_ECHO_START(); SERIAL_ECHOLNPGM_P(lcd_error); }
 
   #if EITHER(HAS_DISPLAY, DWIN_CREALITY_LCD_ENHANCED)
-    ui.kill_screen(lcd_error ?: GET_TEXT(MSG_KILLED), lcd_component ?: NUL_STR);
+    UNUSED(lcd_error); UNUSED(lcd_component);
   #else
     UNUSED(lcd_error); UNUSED(lcd_component);
   #endif


### PR DESCRIPTION
`HAS_DISPLAY` is now defined for LCD progress updates. This enabled a call to `ui.kill_screen()` which is not needed on the SV06 Plus.