### PR TITLE
Don't execute custom print finish code when printing from SD card

### DIFF
--- a/Marlin/src/lcd/sv06p/LCD_RTS.cpp
+++ b/Marlin/src/lcd/sv06p/LCD_RTS.cpp
@@ -2982,6 +2982,9 @@ void RTS_USBPrint_Set() {
 }
 
 void RTS_USBPrint_Finish() {
+    if (card.isPrinting()) {
+        return;
+    }
     if (PrintFlag == 0) {
         return;
     }


### PR DESCRIPTION
The SV06 Plus normally displays a finished print status screen with a "Finish print" button when finishing a print from the SD card. The M73 print progress for external printing inadvertently overrode this feature. This change restores the default behavior when printing from the SD card.